### PR TITLE
resoucesPath() → resourcesFolder

### DIFF
--- a/extensionLib/angleRatioTool.py
+++ b/extensionLib/angleRatioTool.py
@@ -15,7 +15,7 @@ from merz.tools.drawingTools import NSImageDrawingTools
 #     erik@letterror.com
 
 angleRatioToolBundle = ExtensionBundle("AngleRatioTool")
-toolbarIconPath = os.path.join(angleRatioToolBundle.resourcesPath(), "icon.pdf")
+toolbarIconPath = os.path.join(angleRatioToolBundle.resourcesFolder, "icon.pdf")
 toolbarIcon = AppKit.NSImage.alloc().initWithContentsOfFile_(toolbarIconPath)
 
 


### PR DESCRIPTION
- hopefully solving a deprecation warning involving resoucesPath() and resourcesFolder